### PR TITLE
FitNesse plugins

### DIFF
--- a/FitNesseRoot/PlugIns/content.txt
+++ b/FitNesseRoot/PlugIns/content.txt
@@ -35,6 +35,11 @@
 !2 Source control !anchor scm
 |!meta Plugin or Accessory |!meta Author |!meta URL |!meta Docs |
 |TFS Source Control Plugin          |Lars-Erik Aabech @bleedo                          |http://sourceforge.net/projects/fitnessetfs/    |[[docs][http://fitnessetfs.sourceforge.net/]]                                                                                                                       |
+|Git Source Control Plugin          |Tim Andersen @timander                            |https://github.com/timander/fitnesse-git-plugin |[[docs][https://github.com/timander/fitnesse-git-plugin/blob/master/README]]                                                                                        |
+
+!2 Security !anchor scm
+|!meta Plugin or Accessory |!meta Author |!meta URL |!meta Docs |
+|!-FitNesse LDAP Authenticator-!         |Tim Andersen @timander                            |https://github.com/timander/fitnesse-ldap-authenticator |[[docs][https://github.com/timander/fitnesse-ldap-authenticator/blob/master/README]] (for use with !-ActiveDirectory-! or LDAP)                        |
 
 !2 SLiM fixtures !anchor slimfixtures
 !3 Web application fixtures


### PR DESCRIPTION
Hi Dan, I have two plugins that we have been using with FitNesse. Take a look at my github account to see them. We use the fitnesse-git-plugin as a convenience for our business analysts (developers check in changes from IntellIJ or command line). The fitnesse-ldap-authenticator was something I did as an experiment to use Active Directory to secure areas of FitNesse.
