### PR TITLE
SVN Connector plugin added to scm plugins

### DIFF
--- a/FitNesseRoot/PlugIns/content.txt
+++ b/FitNesseRoot/PlugIns/content.txt
@@ -39,6 +39,7 @@ For !-FitNesse-! 20130530 and older.
 |!meta Plugin or Accessory|!meta Author            |!meta URL                                      |!meta Docs                                                                  |
 |TFS Source Control Plugin|Lars-Erik Aabech @bleedo|http://sourceforge.net/projects/fitnessetfs/   |[[docs][http://fitnessetfs.sourceforge.net/]]                               |
 |Git Source Control Plugin|Tim Andersen @timander  |https://github.com/timander/fitnesse-git-plugin|[[docs][https://github.com/timander/fitnesse-git-plugin/blob/master/README]]|
+|SVN Source Control Plugin|Attila Sragli, Gergely Filip, Zoltan Matyas  |https://bitbucket.org/clibre44/svnfileversionscontroller|[[docs][https://bitbucket.org/clibre44/svnfileversionscontroller/wiki/Home]]|
 
 !2 Security !anchor scm
 |!meta Plugin or Accessory      |!meta Author          |!meta URL                                              |!meta Docs                                                                                                                     |


### PR DESCRIPTION
FITNESSE-SUBVERSION Plugin
Written by Gergely Filip, Attila Sragli and Zoltan Matyas.
Provides Subversion integration with FitNesse from version 20150301 as CM version management API has been deprecated.
This code uses SVNKit, for which source code may be obtained from http://svnkit.com/

Wiki:
https://bitbucket.org/clibre44/svnfileversionscontroller/wiki/Home